### PR TITLE
feat(post): post 관련 counts 값 조회 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
         "@types/color-thief-node": "^1.0.4",
+        "@upstash/redis": "^1.34.4",
         "@vercel/analytics": "^1.4.1",
         "chzzk": "^1.10.4",
         "classnames": "^2.5.1",
@@ -2863,6 +2864,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.4",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.4.tgz",
+      "integrity": "sha512-AZx2iD5s1Pu/KCrRA7KVCffu3NSoaYnNY7N9YI7aLAYhcJfsriQKTe+8OxQWJqGqFbrvm17Lyr9HFnDLvqNpfA==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
@@ -3558,6 +3568,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-what": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
     "@types/color-thief-node": "^1.0.4",
+    "@upstash/redis": "^1.34.4",
     "@vercel/analytics": "^1.4.1",
     "chzzk": "^1.10.4",
     "classnames": "^2.5.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -386,6 +386,7 @@ model posts {
   content     Json
   author_id   String     @db.Uuid
   category_id String
+  view_count  BigInt     @default(0)
   comments    comments[]
   likes       likes[]
   users       users      @relation(fields: [author_id], references: [id], onDelete: Cascade)

--- a/src/actions/post-action.ts
+++ b/src/actions/post-action.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/utils/supabase/server';
 import { editorExtensions } from '@/utils/tiptap';
 import { PrismaClient } from '@prisma/client';
 import { generateText } from '@tiptap/react';
+import { Redis } from '@upstash/redis';
 import { redirect } from 'next/navigation';
 import { z } from 'zod';
 
@@ -228,3 +229,21 @@ export async function deletePost(option: z.infer<typeof DeletePostOption>) {
 
   redirect('/community');
 }
+
+export const fetchCounts = async (postId: string) => {
+  const redis = Redis.fromEnv();
+  const prisma = new PrismaClient();
+
+  const viewCount =
+    (await redis.get<number>(['pageviews', 'projects', postId].join(':'))) ?? 0;
+
+  const commentCount = await prisma.comments.count({
+    where: { post_id: Number(postId), deleted_at: null },
+  });
+
+  const likeCount = await prisma.likes.count({
+    where: { post_id: Number(postId), is_liked: true },
+  });
+
+  return { viewCount, commentCount, likeCount };
+};

--- a/src/actions/post-action.ts
+++ b/src/actions/post-action.ts
@@ -231,11 +231,15 @@ export async function deletePost(option: z.infer<typeof DeletePostOption>) {
 }
 
 export const fetchCounts = async (postId: string) => {
-  const redis = Redis.fromEnv();
   const prisma = new PrismaClient();
 
-  const viewCount =
-    (await redis.get<number>(['pageviews', 'projects', postId].join(':'))) ?? 0;
+  const post = await prisma.posts.findUnique({
+    where: { id: Number(postId), deleted_at: null },
+  });
+
+  if (!post) {
+    throw new Error('존재하지 않는 게시글입니다.');
+  }
 
   const commentCount = await prisma.comments.count({
     where: { post_id: Number(postId), deleted_at: null },
@@ -245,5 +249,5 @@ export const fetchCounts = async (postId: string) => {
     where: { post_id: Number(postId), is_liked: true },
   });
 
-  return { viewCount, commentCount, likeCount };
+  return { viewCount: post.view_count, commentCount, likeCount };
 };

--- a/src/app/(main-layout)/(community-layout)/post/[id]/_components/post-box.tsx
+++ b/src/app/(main-layout)/(community-layout)/post/[id]/_components/post-box.tsx
@@ -13,30 +13,29 @@ export interface PostBoxProps {
   category: string;
   author: string;
   authorImageUrl?: string;
-  commentCount: number;
   createdAt: string;
   updatedAt: string;
   content: string;
+  counts: {
+    likeCount: number;
+    viewCount: number;
+    commentCount: number;
+  };
 }
 
 export const PostBox = async (props: PostBoxProps) => {
-  const prisma = new PrismaClient();
-
-  const likeCount = await prisma.likes.count({
-    where: { post_id: Number(props.id), is_liked: true },
-  });
-
   const recommended = await getRecommended(props.id);
 
   return (
     <Card className="flex flex-col">
       <div className="flex flex-col">
         <PostHeader
+          id={props.id}
           title={props.title}
           category={props.category}
           author={props.author}
           authorImageUrl={props.authorImageUrl}
-          commentCount={props.commentCount}
+          counts={props.counts}
           createdAt={props.createdAt}
           updatedAt={props.updatedAt}
         />
@@ -46,7 +45,7 @@ export const PostBox = async (props: PostBoxProps) => {
         />
         <div className="mx-auto my-5 flex w-full flex-col items-center gap-2">
           <Like postId={props.id} recommended={recommended} />
-          <span className="text-white">{likeCount}</span>
+          <span className="text-white">{props.counts.likeCount}</span>
         </div>
       </div>
     </Card>

--- a/src/app/(main-layout)/(community-layout)/post/[id]/_components/post-header.tsx
+++ b/src/app/(main-layout)/(community-layout)/post/[id]/_components/post-header.tsx
@@ -4,16 +4,21 @@ import { getTimeDifference } from '@/utils/time';
 import Image from 'next/image';
 
 export interface PostHeaderProps {
+  id: number;
   title: string;
   category: string;
   author: string;
   authorImageUrl?: string;
-  commentCount: number;
   createdAt: string;
   updatedAt: string;
+  counts: {
+    likeCount: number;
+    viewCount: number;
+    commentCount: number;
+  };
 }
 
-export const PostHeader = (props: PostHeaderProps) => {
+export const PostHeader = async (props: PostHeaderProps) => {
   return (
     <CardHeader className="flex flex-col px-6 py-5">
       <p className="mb-2 text-xs">{props.category}</p>
@@ -35,27 +40,8 @@ export const PostHeader = (props: PostHeaderProps) => {
             suppressHydrationWarning
           >{` · ${getTimeDifference(props.createdAt)} ${props.createdAt !== props.updatedAt ? '(수정됨)' : ''}`}</p>
         </div>
-        <PostIcons commentCount={props.commentCount} />
+        <PostIcons counts={props.counts} />
       </div>
     </CardHeader>
   );
 };
-
-// const Container = styled.div<{ isScrollDown: boolean }>`
-//   position: sticky;
-//   top: ${({ isScrollDown }) => (isScrollDown ? '16px' : '88px')};
-//   transition: top 0.2s ease-in-out;
-//   box-shadow: ${({ theme }) => `0px 4px 8px ${theme.boxShadow}`};
-//   display: flex;
-//   flex-direction: column;
-//   justify-content: center;
-//   border-radius: 16px;
-//   min-height: 97px;
-//   border-bottom: 1px solid ${(prop) => prop.theme.border};
-//   padding: 0 24px;
-//   background-color: ${(prop) => prop.theme.cardHeader};
-//   backdrop-filter: blur(4px);
-//   svg {
-//     margin-right: 4px;
-//   }
-// `;

--- a/src/app/(main-layout)/(community-layout)/post/[id]/_components/report-view.tsx
+++ b/src/app/(main-layout)/(community-layout)/post/[id]/_components/report-view.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+
+interface Props {
+  slug: string;
+  children: ReactNode;
+}
+
+export const ReportView = ({ slug, children }: Props) => {
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/post/view`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ slug }),
+    });
+  }, [slug]);
+
+  return <>{children}</>;
+};

--- a/src/app/(main-layout)/(community-layout)/post/[id]/page.tsx
+++ b/src/app/(main-layout)/(community-layout)/post/[id]/page.tsx
@@ -1,7 +1,8 @@
 import { CommentBox } from './_components/comment-box';
 import { PostBox } from './_components/post-box';
 import { PostDeleteButton } from './_components/post-delete-button';
-import { deletePost } from '@/actions/post-action';
+import { ReportView } from './_components/report-view';
+import { deletePost, fetchCounts } from '@/actions/post-action';
 import { Button } from '@/components';
 import { createClient } from '@/utils/supabase/server';
 import { editorExtensions } from '@/utils/tiptap';
@@ -22,7 +23,6 @@ const fetchPost = async (id: string) => {
     where: { id: Number(id), deleted_at: null },
     include: {
       categories: true,
-      _count: { select: { comments: true } },
     },
   });
 
@@ -73,7 +73,8 @@ export async function generateMetadata(
 }
 
 const PostPage = async ({ params }: Props) => {
-  const post = await fetchPost((await params).id);
+  const { id: postId } = await params;
+  const post = await fetchPost(postId);
 
   if (!post) {
     return notFound();
@@ -82,38 +83,45 @@ const PostPage = async ({ params }: Props) => {
   const userId = await fetchUserId();
   const hasOwn = userId !== null && userId === post.author_id;
 
+  const counts = await fetchCounts(postId);
+
   return (
-    <div className="flex-auto flex-col gap-4">
-      <PostBox
-        id={Number(post.id)}
-        title={post.title}
-        category={post.categories.name}
-        author={post.authorProfile?.nickname ?? 'Unknown'}
-        authorImageUrl={post.authorProfile?.profile_img ?? undefined}
-        commentCount={post._count.comments}
-        createdAt={post.created_at.toISOString()}
-        updatedAt={post.updated_at.toISOString()}
-        content={post.content}
-      />
-      <div className="mb-8 mt-4 flex justify-between" suppressHydrationWarning>
-        <Link href={`/community?category=${post.category_id}`}>
-          <Button sort="secondary">목록</Button>
-        </Link>
-        {hasOwn ? (
-          <div className="flex gap-2">
-            <Link href={`/modify/${post.id}`}>
-              <Button sort="secondary">수정하기</Button>
-            </Link>
-            <PostDeleteButton id={post.id} />
-          </div>
-        ) : (
-          <Button sort="danger" disabled>
-            신고하기
-          </Button>
-        )}
+    <ReportView slug={postId}>
+      <div className="flex-auto flex-col gap-4">
+        <PostBox
+          id={Number(post.id)}
+          title={post.title}
+          category={post.categories.name}
+          author={post.authorProfile?.nickname ?? 'Unknown'}
+          authorImageUrl={post.authorProfile?.profile_img ?? undefined}
+          createdAt={post.created_at.toISOString()}
+          updatedAt={post.updated_at.toISOString()}
+          content={post.content}
+          counts={counts}
+        />
+        <div
+          className="mb-8 mt-4 flex justify-between"
+          suppressHydrationWarning
+        >
+          <Link href={`/community?category=${post.category_id}`}>
+            <Button sort="secondary">목록</Button>
+          </Link>
+          {hasOwn ? (
+            <div className="flex gap-2">
+              <Link href={`/modify/${post.id}`}>
+                <Button sort="secondary">수정하기</Button>
+              </Link>
+              <PostDeleteButton id={post.id} />
+            </div>
+          ) : (
+            <Button sort="danger" disabled>
+              신고하기
+            </Button>
+          )}
+        </div>
+        <CommentBox postId={post.id} />
       </div>
-      <CommentBox postId={post.id} />
-    </div>
+    </ReportView>
   );
 };
 

--- a/src/app/api/post/view/route.ts
+++ b/src/app/api/post/view/route.ts
@@ -1,0 +1,50 @@
+import { Redis } from '@upstash/redis';
+import { NextRequest, NextResponse } from 'next/server';
+
+const redis = Redis.fromEnv();
+export const config = {
+  runtime: 'edge',
+};
+
+export async function POST(req: NextRequest) {
+  if (req.method !== 'POST') {
+    return new NextResponse('use POST', { status: 405 });
+  }
+  if (req.headers.get('Content-Type') !== 'application/json') {
+    return NextResponse.json({ message: 'must be json' }, { status: 400 });
+  }
+
+  const body = await req.json();
+  let slug: string | undefined = undefined;
+  if ('slug' in body) {
+    slug = body.slug;
+  }
+  if (!slug) {
+    return NextResponse.json({ message: 'Slug not found' }, { status: 400 });
+  }
+
+  const ip = (req.headers.get('x-forwarded-for') || '').split(',')[0].trim();
+
+  if (ip) {
+    const buf = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(ip),
+    );
+    const hash = Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+
+    const isNew = await redis.set(['deduplicate', hash, slug].join(':'), true, {
+      nx: true,
+      ex: 24 * 60 * 60,
+    });
+
+    if (!isNew) {
+      return NextResponse.json(null, { status: 202 });
+    }
+  }
+
+  await redis.incr(['pageviews', 'projects', slug].join(':'));
+
+  return NextResponse.json(null, { status: 202 });
+}

--- a/src/app/api/post/view/route.ts
+++ b/src/app/api/post/view/route.ts
@@ -1,3 +1,4 @@
+import { PrismaClient } from '@prisma/client';
 import { Redis } from '@upstash/redis';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -13,6 +14,8 @@ export async function POST(req: NextRequest) {
   if (req.headers.get('Content-Type') !== 'application/json') {
     return NextResponse.json({ message: 'must be json' }, { status: 400 });
   }
+
+  const prisma = new PrismaClient();
 
   const body = await req.json();
   let slug: string | undefined = undefined;
@@ -44,7 +47,16 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  await redis.incr(['pageviews', 'projects', slug].join(':'));
+  await prisma.posts.update({
+    where: {
+      id: Number(slug),
+    },
+    data: {
+      view_count: {
+        increment: 1,
+      },
+    },
+  });
 
   return NextResponse.json(null, { status: 202 });
 }

--- a/src/components/post-icons.tsx
+++ b/src/components/post-icons.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
 
 export interface PostIconsProps {
-  commentCount: number;
+  counts: {
+    commentCount: number;
+    viewCount: number;
+    likeCount: number;
+  };
 }
 
 export const PostIcons = (props: PostIconsProps) => {
   return (
-    <div suppressHydrationWarning className="flex items-center">
+    <div suppressHydrationWarning className="flex items-center gap-5">
       <p className="text-secondary flex items-center text-xs">
-        <span className="icon icon-16 mr-1">
-          comment
-        </span>
-        {props.commentCount}
+        <span className="icon icon-16 mr-1">comment</span>
+        {props.counts.commentCount}
+      </p>
+      <p className="text-secondary flex items-center text-xs">
+        <span className="icon icon-16 mr-1">visibility</span>
+        {props.counts.viewCount}
+      </p>
+      <p className="text-secondary flex items-center text-xs">
+        <span className="icon icon-16 mr-1">favorite</span>
+        {props.counts.likeCount}
       </p>
     </div>
   );

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -1,4 +1,5 @@
 import { PostIcons } from './post-icons';
+import { fetchCounts } from '@/actions/post-action';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -17,8 +18,9 @@ interface Props {
   recommendNum: number;
 }
 
-const PostItem = (props: Props) => {
-  const { category, id, title, text, author, createTime, views } = props;
+const PostItem = async (props: Props) => {
+  const { category, id, title, text, author, createTime } = props;
+  const counts = await fetchCounts(id.toString());
 
   return (
     <Link
@@ -53,7 +55,7 @@ const PostItem = (props: Props) => {
           <span>{author}</span>
           <span className="ml-1 text-gray-400">· {createTime}</span>
         </div>
-        <PostIcons commentCount={props.commentNum} />
+        <PostIcons counts={counts} />
       </div>
     </Link>
   );


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/post/view` → `dev`

<br/>

## ✅ 작업 내용

- upstash를 이용한 조회수 count 기능 구현
  - 유저의 ip를 해싱하여 조회한 post_id 와 함께 저장
  - 조회한 후로 24시간 동안 redis 캐시서버에 남게됨
  - ReportView 컴포넌트 내의 useEffect로 API를 호출하여 API 내부에서 조회수 관련 로직을 처리하도록 구현
- counts 관련 데이터 페칭 함수 분리

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/0b6364ed-4a89-49a0-94fa-387e836a8b13)
![image](https://github.com/user-attachments/assets/c15bab8b-1d95-47ed-9ddd-16ba4f3b8de2)
![image](https://github.com/user-attachments/assets/4547e7f6-e992-41a8-b239-7de897ff8be1)

<br/>

## ✏️ 앞으로의 과제

- 프로덕션 환경에서 조회수 제대로 동작하는지 확인 필요함
- 조회수 count 값 Redis 에서 supabase DB 속성으로 변경